### PR TITLE
feat: implement paginated blog list on /blog page

### DIFF
--- a/src/routes/blog/+page.server.ts
+++ b/src/routes/blog/+page.server.ts
@@ -1,0 +1,52 @@
+import { db } from '$lib/server/db/index.js';
+import { blog } from '$lib/server/db/schema.js';
+import { desc } from 'drizzle-orm';
+
+const POSTS_PER_PAGE = 10;
+
+export async function load({ url }) {
+	const page = parseInt(url.searchParams.get('page') || '1', 10);
+	const offset = (page - 1) * POSTS_PER_PAGE;
+
+	// Get total count for pagination
+	const totalPosts = await db.select().from(blog).all();
+	const totalCount = totalPosts.length;
+	const totalPages = Math.ceil(totalCount / POSTS_PER_PAGE);
+
+	// Get paginated posts (ordered by slug for consistent ordering)
+	const posts = await db
+		.select({
+			slug: blog.slug,
+			title: blog.title,
+			content: blog.content
+		})
+		.from(blog)
+		.orderBy(desc(blog.slug))
+		.limit(POSTS_PER_PAGE)
+		.offset(offset)
+		.all();
+
+	// Create excerpts from content (strip HTML and truncate)
+	const postsWithExcerpts = posts.map((post) => {
+		// Strip HTML tags and get first ~200 characters
+		const plainText = post.content.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+		const excerpt = plainText.length > 200 ? plainText.substring(0, 200) + '...' : plainText;
+		
+		return {
+			slug: post.slug,
+			title: post.title,
+			excerpt
+		};
+	});
+
+	return {
+		posts: postsWithExcerpts,
+		pagination: {
+			currentPage: page,
+			totalPages,
+			totalCount,
+			hasNextPage: page < totalPages,
+			hasPrevPage: page > 1
+		}
+	};
+}

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,1 +1,62 @@
-WIP
+<script lang="ts">
+	let { data } = $props();
+</script>
+
+<svelte:head>
+	<title>The Blog of Alexandria - All Posts</title>
+</svelte:head>
+
+<div>
+	<h1 class="text-center">All Blog Posts</h1>
+	
+	{#if data.posts.length === 0}
+		<p>No blog posts found. Create some by visiting specific blog URLs!</p>
+	{:else}
+		{#each data.posts as post}
+			<article class="not-prose mb-8 border-b pb-6 last:border-b-0">
+				<h2>
+					<a href="/blog/{post.slug}" class="text-decoration-none">
+						{post.title}
+					</a>
+				</h2>
+				<p class="text-gray-700 leading-relaxed">
+					{post.excerpt}
+				</p>
+				<a href="/blog/{post.slug}" class="text-decoration-none">
+					Read more →
+				</a>
+			</article>
+		{/each}
+
+		<!-- Pagination -->
+		{#if data.pagination.totalPages > 1}
+			<div class="not-prose text-center mt-8">
+				{#if data.pagination.hasPrevPage}
+					<a
+						href="/blog?page={data.pagination.currentPage - 1}"
+						class="text-decoration-none mr-4"
+					>
+						← Previous
+					</a>
+				{/if}
+
+				<span class="mx-4">
+					Page {data.pagination.currentPage} of {data.pagination.totalPages}
+				</span>
+
+				{#if data.pagination.hasNextPage}
+					<a
+						href="/blog?page={data.pagination.currentPage + 1}"
+						class="text-decoration-none ml-4"
+					>
+						Next →
+					</a>
+				{/if}
+
+				<p class="text-sm text-gray-500 mt-2">
+					Showing {data.posts.length} of {data.pagination.totalCount} posts
+				</p>
+			</div>
+		{/if}
+	{/if}
+</div>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -29,11 +29,11 @@
 		{/each}
 
 		<!-- Pagination -->
-		{#if data.pagination.totalPages > 1}
+		{#if data.pagination.total_pages > 1}
 			<div class="not-prose text-center mt-8">
-				{#if data.pagination.hasPrevPage}
+				{#if data.pagination.has_prev_page}
 					<a
-						href="/blog?page={data.pagination.currentPage - 1}"
+						href="/blog?page={data.pagination.current_page - 1}"
 						class="text-decoration-none mr-4"
 					>
 						← Previous
@@ -41,12 +41,12 @@
 				{/if}
 
 				<span class="mx-4">
-					Page {data.pagination.currentPage} of {data.pagination.totalPages}
+					Page {data.pagination.current_page} of {data.pagination.total_pages}
 				</span>
 
-				{#if data.pagination.hasNextPage}
+				{#if data.pagination.has_next_page}
 					<a
-						href="/blog?page={data.pagination.currentPage + 1}"
+						href="/blog?page={data.pagination.current_page + 1}"
 						class="text-decoration-none ml-4"
 					>
 						Next →
@@ -54,7 +54,7 @@
 				{/if}
 
 				<p class="text-sm text-gray-500 mt-2">
-					Showing {data.posts.length} of {data.pagination.totalCount} posts
+					Showing {data.posts.length} of {data.pagination.total_count} posts
 				</p>
 			</div>
 		{/if}


### PR DESCRIPTION
Implements a paginated blog list on `/blog` with:

- Server-side pagination logic with 10 posts per page
- Display blog titles with excerpts from content
- Navigation between pages with query parameter support
- Consistent styling with existing design patterns
- Total post count and current page info

Closes #2

Generated with [Claude Code](https://claude.ai/code)