### PR TITLE
feat: make blog post titles bigger and bolder

### DIFF
--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -14,7 +14,7 @@
 	{:else}
 		{#each data.posts as post}
 			<article class="not-prose mb-8 border-b pb-6 last:border-b-0">
-				<h2>
+				<h2 class="text-3xl font-bold mb-3">
 					<a href="/blog/{post.slug}" class="text-decoration-none">
 						{post.title}
 					</a>


### PR DESCRIPTION
This PR improves the blog page design by making titles more prominent:

- Added `text-3xl` for larger font size
- Added `font-bold` for bold weight
- Added `mb-3` for better spacing

Fixes #4

Generated with [Claude Code](https://claude.ai/code)