### PR TITLE
Add created_at field to blogs and update sorting

### DIFF
--- a/drizzle/0002_green_sphinx.sql
+++ b/drizzle/0002_green_sphinx.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `__new_blog` (
+	`slug` text PRIMARY KEY NOT NULL,
+	`content` text NOT NULL,
+	`title` text NOT NULL DEFAULT 'Untitled',
+	`created_at` integer NOT NULL DEFAULT (unixepoch())
+);
+--> statement-breakpoint
+INSERT INTO `__new_blog`("slug", "content", "title") SELECT "slug", "content", "title" FROM `blog`;
+--> statement-breakpoint
+DROP TABLE `blog`;
+--> statement-breakpoint
+ALTER TABLE `__new_blog` RENAME TO `blog`;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,58 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ba332cc8-5739-4b3c-8565-49b47108f739",
+  "prevId": "feb670ae-a932-4eb1-ad8e-2587ac63969d",
+  "tables": {
+    "blog": {
+      "name": "blog",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Untitled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1754686762260,
       "tag": "0001_glamorous_mandroid",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1754733582429,
+      "tag": "0002_green_sphinx",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,7 +1,9 @@
-import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
 
 export const blog = sqliteTable('blog', {
 	slug: text('slug').primaryKey(),
 	content: text('content').notNull(),
-	title: text('title').notNull().default('Untitled')
+	title: text('title').notNull().default('Untitled'),
+	created_at: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`)
 });

--- a/src/routes/blog/+page.server.ts
+++ b/src/routes/blog/+page.server.ts
@@ -19,7 +19,7 @@ export async function load({ url }) {
 	const [{ total_count }] = await db.select({ total_count: count() }).from(blog);
 	const total_pages = Math.ceil(total_count / posts_per_page);
 
-	// Get paginated posts (ordered by slug for consistent ordering)
+	// Get paginated posts (ordered by created_at descending - newest first)
 	const posts = await db
 		.select({
 			slug: blog.slug,
@@ -27,7 +27,7 @@ export async function load({ url }) {
 			content: blog.content
 		})
 		.from(blog)
-		.orderBy(desc(blog.slug))
+		.orderBy(desc(blog.created_at))
 		.limit(posts_per_page)
 		.offset(offset)
 		.all();

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -8,34 +8,29 @@
 
 <div>
 	<h1 class="text-center">All Blog Posts</h1>
-	
+
 	{#if data.posts.length === 0}
 		<p>No blog posts found. Create some by visiting specific blog URLs!</p>
 	{:else}
-		{#each data.posts as post}
+		{#each data.posts as post (post.slug)}
 			<article class="not-prose mb-8 border-b pb-6 last:border-b-0">
-				<h2 class="text-3xl font-bold mb-3">
+				<h2 class="mb-3 text-3xl font-bold">
 					<a href="/blog/{post.slug}" class="text-decoration-none">
 						{post.title}
 					</a>
 				</h2>
-				<p class="text-gray-700 leading-relaxed">
+				<p class="leading-relaxed text-gray-700">
 					{post.excerpt}
 				</p>
-				<a href="/blog/{post.slug}" class="text-decoration-none">
-					Read more →
-				</a>
+				<a href="/blog/{post.slug}" class="text-decoration-none"> Read more → </a>
 			</article>
 		{/each}
 
 		<!-- Pagination -->
 		{#if data.pagination.total_pages > 1}
-			<div class="not-prose text-center mt-8">
+			<div class="not-prose mt-8 text-center">
 				{#if data.pagination.has_prev_page}
-					<a
-						href="/blog?page={data.pagination.current_page - 1}"
-						class="text-decoration-none mr-4"
-					>
+					<a href="/blog?page={data.pagination.current_page - 1}" class="text-decoration-none mr-4">
 						← Previous
 					</a>
 				{/if}
@@ -45,15 +40,12 @@
 				</span>
 
 				{#if data.pagination.has_next_page}
-					<a
-						href="/blog?page={data.pagination.current_page + 1}"
-						class="text-decoration-none ml-4"
-					>
+					<a href="/blog?page={data.pagination.current_page + 1}" class="text-decoration-none ml-4">
 						Next →
 					</a>
 				{/if}
 
-				<p class="text-sm text-gray-500 mt-2">
+				<p class="mt-2 text-sm text-gray-500">
 					Showing {data.posts.length} of {data.pagination.total_count} posts
 				</p>
 			</div>


### PR DESCRIPTION
Fixes ##8

## Changes
- Add `created_at` timestamp field to blog schema with automatic population
- Update blog list sorting to use `created_at` (newest first) instead of `slug`
- Field automatically populates using SQLite unixepoch() function

## Database Migration Required
After merging, run these commands to apply the schema changes:
```bash
pnpm db:generate
pnpm db:push
```

Generated with [Claude Code](https://claude.ai/code)