### PR TITLE
fix: save slug record immediately to prevent race conditions

### DIFF
--- a/src/routes/blog/[...slug]/+page.server.ts
+++ b/src/routes/blog/[...slug]/+page.server.ts
@@ -31,14 +31,13 @@ export async function load({ params: { slug } }) {
 		};
 	}
 	
-	// Save empty record immediately to prevent race conditions
-	const placeholderTitle = 'Generating...';
-	const placeholderContent = '<p>Content is being generated, please wait...</p>';
-	
+	// Save empty record immediately to prevent race conditions from multiple users
+	// accessing the same slug simultaneously. Empty strings allow frontend to detect
+	// loading state and show proper loading UI.
 	await db.insert(blog).values({ 
 		slug, 
-		title: placeholderTitle, 
-		content: placeholderContent 
+		title: '', 
+		content: '' 
 	}).execute();
 	
 	const { promise: content, resolve } = Promise.withResolvers();


### PR DESCRIPTION
Fixes race condition where multiple users accessing the same ungenerated slug could trigger simultaneous OpenAI generations.

## Changes
- Save placeholder record immediately when slug is first accessed
- Update existing record when generation completes
- Prevents race conditions from page refreshes or concurrent access

Closes #10

Generated with [Claude Code](https://claude.ai/code)