### PR TITLE
feat: filter reasoning steps from got-oss responses

### DIFF
--- a/src/lib/server/openai/index.ts
+++ b/src/lib/server/openai/index.ts
@@ -7,6 +7,6 @@ export const openai = new OpenAI({
 });
 
 export function parse_final_message(content: string): string {
-	const finalMessageMatch = content.match(/<\|channel\|>final<\|message\|>(.+)$/s);
-	return finalMessageMatch ? finalMessageMatch[1].trim() : content;
+	const final_message_match = content.match(/<\|channel\|>final<\|message\|>(.+)$/s);
+	return final_message_match ? final_message_match[1].trim() : content;
 }

--- a/src/lib/server/openai/index.ts
+++ b/src/lib/server/openai/index.ts
@@ -5,3 +5,8 @@ export const openai = new OpenAI({
 	baseURL: 'https://openrouter.ai/api/v1',
 	apiKey: OPENROUTER_API_KEY
 });
+
+export function parseFinalMessage(content: string): string {
+	const finalMessageMatch = content.match(/<\|channel\|>final<\|message\|>(.+)$/s);
+	return finalMessageMatch ? finalMessageMatch[1].trim() : content;
+}

--- a/src/lib/server/openai/index.ts
+++ b/src/lib/server/openai/index.ts
@@ -6,7 +6,7 @@ export const openai = new OpenAI({
 	apiKey: OPENROUTER_API_KEY
 });
 
-export function parseFinalMessage(content: string): string {
+export function parse_final_message(content: string): string {
 	const finalMessageMatch = content.match(/<\|channel\|>final<\|message\|>(.+)$/s);
 	return finalMessageMatch ? finalMessageMatch[1].trim() : content;
 }

--- a/src/routes/blog/[...slug=slug]/+page.server.ts
+++ b/src/routes/blog/[...slug=slug]/+page.server.ts
@@ -1,6 +1,6 @@
 import { db } from '$lib/server/db/index.js';
 import { blog, type Blog } from '$lib/server/db/schema.js';
-import { openai } from '$lib/server/openai';
+import { openai, parseFinalMessage } from '$lib/server/openai';
 import { fromHighlighter } from '@shikijs/markdown-it';
 import { bundledLanguages, createHighlighter } from 'shiki';
 import { eq } from 'drizzle-orm';
@@ -117,7 +117,7 @@ OUTPUT: Return only the blog post content in markdown format. No meta-commentary
 		})
 		.then((completion) => {
 			if (completion.choices[0].message.content) {
-				const content = completion.choices[0].message.content;
+				const content = parseFinalMessage(completion.choices[0].message.content);
 
 				const [, title] = content
 					.split('\n')[0]

--- a/src/routes/blog/[...slug=slug]/+page.server.ts
+++ b/src/routes/blog/[...slug=slug]/+page.server.ts
@@ -1,6 +1,6 @@
 import { db } from '$lib/server/db/index.js';
 import { blog, type Blog } from '$lib/server/db/schema.js';
-import { openai, parseFinalMessage } from '$lib/server/openai';
+import { openai, parse_final_message } from '$lib/server/openai';
 import { fromHighlighter } from '@shikijs/markdown-it';
 import { bundledLanguages, createHighlighter } from 'shiki';
 import { eq } from 'drizzle-orm';
@@ -117,7 +117,7 @@ OUTPUT: Return only the blog post content in markdown format. No meta-commentary
 		})
 		.then((completion) => {
 			if (completion.choices[0].message.content) {
-				const content = parseFinalMessage(completion.choices[0].message.content);
+				const content = parse_final_message(completion.choices[0].message.content);
 
 				const [, title] = content
 					.split('\n')[0]

--- a/src/routes/random/generate/+server.ts
+++ b/src/routes/random/generate/+server.ts
@@ -1,4 +1,4 @@
-import { openai } from '$lib/server/openai';
+import { openai, parseFinalMessage } from '$lib/server/openai';
 import { redirect } from '@sveltejs/kit';
 import { toJsonSchema } from '@valibot/to-json-schema';
 import { db } from '$lib/server/db/index.js';
@@ -38,7 +38,7 @@ export async function GET() {
 			}
 		});
 
-		url = v.parse(SlugSchemaStrict, JSON.parse(generated.choices[0].message.content ?? '')).slug;
+		url = v.parse(SlugSchemaStrict, JSON.parse(parseFinalMessage(generated.choices[0].message.content ?? ''))).slug;
 	} catch (e) {
 		console.log(e);
 		// Select a random article from the database

--- a/src/routes/random/generate/+server.ts
+++ b/src/routes/random/generate/+server.ts
@@ -1,4 +1,4 @@
-import { openai, parseFinalMessage } from '$lib/server/openai';
+import { openai, parse_final_message } from '$lib/server/openai';
 import { redirect } from '@sveltejs/kit';
 import { toJsonSchema } from '@valibot/to-json-schema';
 import { db } from '$lib/server/db/index.js';
@@ -38,7 +38,7 @@ export async function GET() {
 			}
 		});
 
-		url = v.parse(SlugSchemaStrict, JSON.parse(parseFinalMessage(generated.choices[0].message.content ?? ''))).slug;
+		url = v.parse(SlugSchemaStrict, JSON.parse(parse_final_message(generated.choices[0].message.content ?? ''))).slug;
 	} catch (e) {
 		console.log(e);
 		// Select a random article from the database


### PR DESCRIPTION
Fixes #14

This PR implements filtering of reasoning steps from got-oss responses, extracting only the final message content.

## Changes
- Added `parseFinalMessage()` utility function to extract final message content
- Updated blog post generation to use filtered responses
- Updated random slug generation to use filtered responses
- Maintains backward compatibility if expected pattern not found

Generated with [Claude Code](https://claude.ai/code)